### PR TITLE
Restore Firefox extension keyboard shortcuts

### DIFF
--- a/test/webextension/manifest.json
+++ b/test/webextension/manifest.json
@@ -19,8 +19,38 @@
                 "default": "Shift+Alt+S"
             },
             "description": "Highlight selected text"
+        },
+        "_execute_action": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+E",
+                "windows": "Ctrl+Shift+E",
+                "mac": "Command+Shift+E",
+                "chromeos": "Ctrl+Shift+E",
+                "linux": "Ctrl+Shift+E"
+            }
+        },
+        "save-page": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+O",
+                "windows": "Ctrl+Shift+O",
+                "mac": "Command+Shift+O",
+                "chromeos": "Ctrl+Shift+O",
+                "linux": "Ctrl+Shift+O"
+            },
+            "description": "__MSG_savePage__"
+        },
+        "show-bookmarks": {
+            "description": "__MSG_myBookmarks__",
+            "suggested_key": {
+                "default": "Ctrl+Shift+A",
+                "windows": "Ctrl+Shift+A",
+                "mac": "Command+Shift+A",
+                "chromeos": "Ctrl+Shift+A",
+                "linux": "Ctrl+Shift+A"
+            }
         }
     },
+
     "permissions": [
         "activeTab",
         "contextMenus"


### PR DESCRIPTION
Restores Firefox extension keyboard shortcuts, which [currently](https://github.com/raindropio/highlight/issues/2) [don't work](https://github.com/raindropio/app/issues/121). 

I took most of the code from the [legacy Manifest V2 extension `manifest.json`](https://github.com/raindropio/extensions/blob/master/src/config/manifest.json), except for changing `"_execute_browser_action"` to `"_execute_action"` for [Manifest V3 compatibility](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#syntax).